### PR TITLE
Dropped `load_dotenv` usages

### DIFF
--- a/langgraph_jury_deliberation.ipynb
+++ b/langgraph_jury_deliberation.ipynb
@@ -34,8 +34,6 @@
     }
    },
    "source": [
-    "import load_dotenv\n",
-    "\n",
     "# Packages should be pre-installed in the environment\n",
     "# Dependencies: langgraph langchain-openai langchain-core langchain-google-genai pyyaml\n",
     "pass"
@@ -78,8 +76,7 @@
     "from langchain_core.messages import BaseMessage, HumanMessage, AIMessage\n",
     "from langchain_openai import ChatOpenAI\n",
     "from langchain_core.prompts import ChatPromptTemplate\n",
-    "from langchain_google_genai import ChatGoogleGenerativeAI\n",
-    "import os"
+    "from langchain_google_genai import ChatGoogleGenerativeAI"
    ],
    "outputs": [],
    "execution_count": 75
@@ -104,6 +101,7 @@
     }
    },
    "source": [
+    "import os\n",
     "import yaml\n",
     "from IPython.display import Image, display\n",
     "from datetime import datetime\n",
@@ -145,11 +143,11 @@
    },
    "source": [
     "# Read API key from environment variable or file\n",
-    "import os\n",
-    "import load_dotenv\n",
+    "\n",
+    "# import load_dotenv --> from dotenv import load_dotenv\n",
     "\n",
     "# First try to get API key from environment variable (for Cloud Run)\n",
-    "load_dotenv.load_dotenv()\n",
+    "# load_dotenv.load_dotenv() --> load_dotenv()\n",
     "api_key = os.environ.get('GOOGLE_API_KEY')\n",
     "# print(api_key)\n",
     "api_key_source = \"environment variable\"\n",


### PR DESCRIPTION
Dropped (commented out) `load_dotenv` usages due to package mismatches